### PR TITLE
avoid SQL error in case a user exists in a external directory but not in...

### DIFF
--- a/userlogintracking.php
+++ b/userlogintracking.php
@@ -64,6 +64,10 @@ class plgUserUserlogintracking extends JPlugin
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
+
+		//in case a user exists in LDAP directory but not in Joomla
+                if ( !isset($this->userID) || $this->userID < ' ' ) return false;
+
 		$columns = array('userid', 'username', 'ip', 'timestamp');
 		$values = array( $this->userID, $db->quote($this->username), $db->quote($this->IP), $this->timestamp);
 		$query


### PR DESCRIPTION
... Joomla

This is the error experienced with the system LDAP plugin enabled
1064
You have an error in your SQL syntax; check the manual that corresponds to your MySQL
server version for the right syntax to use near ....
at line 3 SQL=INSERT INTO `xxxx_userlogin_tracking`
(`userid`,`username`,`ip`,`timestamp`) VALUES (,'xxxx','79.56.247.43',1417120661)

You can see that the userid is null.
